### PR TITLE
Add Social Auth

### DIFF
--- a/frontend/app/auth/signin/google/google-callback-client.tsx
+++ b/frontend/app/auth/signin/google/google-callback-client.tsx
@@ -1,0 +1,56 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { useRouter } from "next/navigation"
+import { useAuth } from "@/components/auth/auth-provider"
+import { LoadingSpinner } from "@/components/ui/loading-spinner"
+
+interface GoogleCallbackClientProps {
+    code: string
+}
+
+export default function GoogleCallbackClient({ code }: GoogleCallbackClientProps) {
+    const router = useRouter()
+    const { socialLogin } = useAuth()
+    const [error, setError] = useState<string | null>(null)
+
+    useEffect(() => {
+        const handleCallback = async () => {
+            try {
+                // Simply pass the code to the backend
+                await socialLogin("google", { code })
+
+                // Redirect is handled in the auth provider
+            } catch (err) {
+                console.error("Google callback error:", err)
+                setError(err instanceof Error ? err.message : "Authentication failed")
+
+                // Redirect to signin page after a delay if there's an error
+                setTimeout(() => {
+                    router.push("/auth/signin")
+                }, 3000)
+            }
+        }
+
+        handleCallback()
+    }, [code, socialLogin, router])
+
+    if (error) {
+        return (
+            <div className="flex flex-col items-center justify-center min-h-screen p-4">
+                <div className="bg-white dark:bg-gray-800 p-8 rounded-lg shadow-md max-w-md w-full">
+                    <h1 className="text-2xl font-bold text-red-600 mb-4">Authentication Error</h1>
+                    <p className="text-gray-700 dark:text-gray-300 mb-4">{error}</p>
+                    <p className="text-gray-500 dark:text-gray-400">Redirecting to sign in page...</p>
+                </div>
+            </div>
+        )
+    }
+
+    return (
+        <div className="flex flex-col items-center justify-center min-h-screen">
+            <LoadingSpinner size="lg" />
+            <p className="mt-4 text-gray-600 dark:text-gray-400">Completing authentication...</p>
+        </div>
+    )
+}

--- a/frontend/app/auth/signin/google/page.tsx
+++ b/frontend/app/auth/signin/google/page.tsx
@@ -1,0 +1,17 @@
+import { redirect } from "next/navigation"
+import GoogleCallbackClient from "./google-callback-client"
+
+export const dynamic = "force-dynamic"
+
+export default function GoogleCallbackPage({
+    searchParams,
+}: {
+    searchParams: { [key: string]: string | string[] | undefined }
+}) {
+    // If there's no code parameter, redirect to the signin page
+    if (!searchParams.code) {
+        redirect("/auth/signin")
+    }
+
+    return <GoogleCallbackClient code={searchParams.code as string} />
+}

--- a/frontend/app/auth/signin/google/page.tsx
+++ b/frontend/app/auth/signin/google/page.tsx
@@ -3,15 +3,19 @@ import GoogleCallbackClient from "./google-callback-client"
 
 export const dynamic = "force-dynamic"
 
-export default function GoogleCallbackPage({
+export default async function GoogleCallbackPage({
     searchParams,
 }: {
     searchParams: { [key: string]: string | string[] | undefined }
 }) {
+    // In Next.js 15, searchParams needs to be awaited
+    const parseSearchParams = await searchParams
+    const code = parseSearchParams.code
+
     // If there's no code parameter, redirect to the signin page
-    if (!searchParams.code) {
+    if (!code) {
         redirect("/auth/signin")
     }
 
-    return <GoogleCallbackClient code={searchParams.code as string} />
+    return <GoogleCallbackClient code={code as string} />
 }

--- a/frontend/components/auth/auth-provider.tsx
+++ b/frontend/components/auth/auth-provider.tsx
@@ -22,7 +22,7 @@ type AuthContextType = {
   user: User | null
   login: (email: string, password: string) => Promise<User | null>
   logout: () => Promise<void>
-  socialLogin: (provider: string, token: string) => Promise<User | null>
+  socialLogin: (provider: string, params: Record<string, string>) => Promise<User | null>
   isAuthenticated: boolean
   isAdmin: boolean
   updateUser: (userData: Partial<User>) => Promise<User | null>
@@ -130,7 +130,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     }
   }
 
-  const socialLogin = async (provider: string, token: string): Promise<User | null> => {
+  const socialLogin = async (provider: string, params: Record<string, string>): Promise<User | null> => {
     try {
       let endpoint = ""
 
@@ -146,7 +146,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({ access_token: token }),
+        body: JSON.stringify(params),
       })
 
       if (!response.ok) {

--- a/frontend/components/auth/social-login.tsx
+++ b/frontend/components/auth/social-login.tsx
@@ -2,39 +2,30 @@
 
 import { useState } from "react"
 import { Button } from "@/components/ui/button"
-import { useAuth } from "@/components/auth/auth-provider"
 import { Loader2 } from "lucide-react"
 
-interface SocialLoginProps {
-  onSuccess?: () => void
-  onError?: (error: Error) => void
-}
+export function SocialLogin() {
+  const [isLoading, setIsLoading] = useState(false)
 
-export function SocialLogin({ onSuccess, onError }: SocialLoginProps) {
-  const { socialLogin } = useAuth()
-  const [isLoading, setIsLoading] = useState<{ [key: string]: boolean }>({
-    google: false,
-    github: false,
-  })
+  // Simplified Google OAuth flow
+  const handleGoogleLogin = () => {
+    setIsLoading(true)
 
-  // In a real implementation, you would use a proper OAuth library
-  // like @react-oauth/google to handle the OAuth flow
-  const handleGoogleLogin = async () => {
-    setIsLoading((prev) => ({ ...prev, google: true }))
     try {
-      // This is a mock implementation
-      // In a real app, you would get this token from Google OAuth
-      const mockGoogleToken = "google-mock-token"
+      // Get the client ID from environment variables
+      const clientId = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID || ""
 
-      // Call the socialLogin function from the auth context
-      await socialLogin("google", mockGoogleToken)
+      // Set the callback URL to our Google sign-in callback route
+      const redirectUri = `${window.location.origin}/auth/signin/google`
 
-      if (onSuccess) onSuccess()
+      // Construct the simplified Google OAuth URL
+      const googleAuthUrl = `https://accounts.google.com/o/oauth2/v2/auth?redirect_uri=${encodeURIComponent(redirectUri)}&prompt=consent&response_type=code&client_id=${clientId}&scope=openid%20email%20profile&access_type=offline`
+
+      // Redirect to Google's OAuth page
+      window.location.href = googleAuthUrl
     } catch (error) {
-      console.error("Google login error:", error)
-      if (onError && error instanceof Error) onError(error)
-    } finally {
-      setIsLoading((prev) => ({ ...prev, google: false }))
+      console.error("Failed to initiate Google login:", error)
+      setIsLoading(false)
     }
   }
 
@@ -54,9 +45,9 @@ export function SocialLogin({ onSuccess, onError }: SocialLoginProps) {
           variant="outline"
           className="w-full flex items-center justify-center gap-2"
           onClick={handleGoogleLogin}
-          disabled={isLoading.google}
+          disabled={isLoading}
         >
-          {isLoading.google ? (
+          {isLoading ? (
             <Loader2 className="h-4 w-4 animate-spin" />
           ) : (
             <svg className="h-5 w-5" viewBox="0 0 24 24">


### PR DESCRIPTION
This pull request implements a Google OAuth login flow, refactors the `socialLogin` function to accept dynamic parameters, and simplifies the `SocialLogin` component. The changes streamline the authentication process and improve code maintainability.

### Google OAuth Integration:
* [`frontend/app/auth/signin/google/google-callback-client.tsx`](diffhunk://#diff-ae576a75033f7af78b8e04675b79ed62caaf6212201726c908cf939a9a554aafR1-R56): Added a new client-side component to handle the Google OAuth callback, process the authorization code, and manage error handling with user feedback.
* [`frontend/app/auth/signin/google/page.tsx`](diffhunk://#diff-4abfc913da345afec58d699f089d2d4a1c76e7615863842b4569ea4796162e57R1-R21): Created a server-side page to parse the OAuth authorization code from query parameters and render the `GoogleCallbackClient` component. Redirects to the sign-in page if the code is missing.

### Refactoring `socialLogin`:
* [`frontend/components/auth/auth-provider.tsx`](diffhunk://#diff-e6afb6c37b6af83d5ec077a96f01939377b356d00cda04a052bab8298ff19221L25-R25): Updated the `socialLogin` function to accept a `params` object instead of a single token, allowing for more flexible parameter handling. Adjusted the API request body to serialize the `params` object. [[1]](diffhunk://#diff-e6afb6c37b6af83d5ec077a96f01939377b356d00cda04a052bab8298ff19221L25-R25) [[2]](diffhunk://#diff-e6afb6c37b6af83d5ec077a96f01939377b356d00cda04a052bab8298ff19221L133-R133) [[3]](diffhunk://#diff-e6afb6c37b6af83d5ec077a96f01939377b356d00cda04a052bab8298ff19221L149-R149)

### Simplification of `SocialLogin` Component:
* [`frontend/components/auth/social-login.tsx`](diffhunk://#diff-ac3490683713ab7c929950a472666617f3937be68ad8fd3426f5906d2192f8d5L5-R28): Simplified the `SocialLogin` component by removing unused props (`onSuccess`, `onError`) and replacing the mock implementation with a real OAuth flow. The Google login button now redirects users to Google's OAuth page with dynamically constructed parameters. [[1]](diffhunk://#diff-ac3490683713ab7c929950a472666617f3937be68ad8fd3426f5906d2192f8d5L5-R28) [[2]](diffhunk://#diff-ac3490683713ab7c929950a472666617f3937be68ad8fd3426f5906d2192f8d5L57-R50)